### PR TITLE
add name to user's edit form

### DIFF
--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -11,6 +11,9 @@
         <p>Currently waiting confirmation for: <%= resource.unconfirmed_email %></p>
       <% end %>
 
+      <%= f.input :name,
+                  required: true,
+                  input_html: { autocomplete: "name" }%>
       <%= f.input :password,
                   hint: "leave it blank if you don't want to change it",
                   required: false,


### PR DESCRIPTION
The form hadn't the column name so to be edited.